### PR TITLE
Lowered I2C Freq from 2000000 to 600000

### DIFF
--- a/Picoroids.py
+++ b/Picoroids.py
@@ -47,7 +47,7 @@ WIDTH  = 128                                            # oled display width
 HEIGHT = 64                                             # oled display height
 
 #i2c = I2C(0)                                            # Init I2C using I2C0 defaults, SCL=Pin(GP9), SDA=Pin(GP8), freq=400000
-i2c = I2C(0, scl=Pin(9), sda=Pin(8), freq=2000000)
+i2c = I2C(0, scl=Pin(9), sda=Pin(8), freq=600000)
 # report i2c address for information 
 print("I2C Address      : "+hex(i2c.scan()[0]).upper()) # Display device address
 print("I2C Configuration: "+str(i2c))                   # Display I2C config


### PR DESCRIPTION
On my display I often ran into OSError: 5 after random amounts of time when using the frequency 2000000. I lowered it to 600000 and it works fine